### PR TITLE
Add a man page for zipserver.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+The man pages in this directory can be generated using the `rst2man` command
+line tool provided by the Python `docutils` project:
+
+    $ rst2man zipserver.rst zipserver.1

--- a/docs/zipserver.rst
+++ b/docs/zipserver.rst
@@ -1,0 +1,41 @@
+=========
+zipserver
+=========
+
+---------------------
+Simple ZIP fileserver
+---------------------
+
+:Author: Louis-Philippe Véronneau
+:Date: 2021
+:Manual section: 1
+
+Synopsis
+========
+
+| zipserver [**--bind** ADDRESS] [**--directory** DIRECTORY] *<port>*
+| zipserver (**-h** \| **--help**)
+
+Description
+===========
+
+**zipserver** is a simple fileserver with support for downloading multiple
+files and folders as a single zip file.
+
+Arguments
+=========
+
+| *<port>*       Specify alternate port. Default: 8000
+
+Options
+=======
+
+| **-h** **--help**  Shows the help message
+| **-b** **--bind**  Specify alternate bind address. Default: all interfaces
+| **--directory**    Specify alternative directory. Default: current directory
+
+Bugs
+====
+
+Bugs can be reported to your distribution's bug tracker or upstream
+at https://github.com/pR0Ps/zipstream-ng/issues.

--- a/docs/zipserver.rst
+++ b/docs/zipserver.rst
@@ -6,7 +6,7 @@ zipserver
 Simple ZIP fileserver
 ---------------------
 
-:Author: Louis-Philippe Véronneau
+:Authors: Manpage written by Louis-Philippe Véronneau
 :Date: 2021
 :Manual section: 1
 


### PR DESCRIPTION
Closes #6.

It would be better to leverage sphinx and generate a more complete documentation using the docstrings available, but this will do (and it's relatively easy to modify).

You can view the resulting manpage by running:

```
cd docs
rst2man zipserver.rst zipserver.1
man ./zipserver.1
```

Cheers,