### PR TITLE
Consider byte streams as non-zero content

### DIFF
--- a/zipstream/ng.py
+++ b/zipstream/ng.py
@@ -692,7 +692,9 @@ class ZipStream:
             # change while we're iterating over it.
             data = bytes(data)
 
-        if data != b'' and arcname[-1] in PATH_SEPARATORS:
+        # If it is not bytes, it is an iterator. Therfore we can assume it has some content,
+        # as we do not want to iterate over it more than once.
+        if arcname[-1] in PATH_SEPARATORS and (not isinstance(data, bytes) or data != b''):
             raise ValueError("Can't store data as a directory")
 
         if isinstance(data, bytes):


### PR DESCRIPTION
In the `add` method of `ZipStream`, there is a check that raises a `ValueError` if one wants to add non-zero-length data as a folder (i.e., with an arcname ending with a slash). This is done checking if `data != b''`.
However, while this check is correct if data is bytes (the lines above the check convert strings and bytearrays to bytes), this might fail if data is an iterator.

Passing an iterator is allowed by the docstring.
In this case, one does not want to start iterating on it to discover if it is data, therefore I think that if data is not bytes, one should just assume that it might have some content, and raise the error.

I am also changing the order of checks, so that `data` is not even checked if the arcname is a file and not a directory.

This fix allows to resolve an issue (inveniosoftware/invenio-app-rdm#2097) with the InvenioRDM software, originating from a combination of the check performed here and another issue with the `fsspec` package when a class from that library is compared with a bytes variable.

If this is merged and a released in a new version of ZipStream, this would allow us to update dependencies in InvenioRDM, fix the bug and close the issue.