### PR TITLE
Prevent mismatches between arcname and data when adding paths

### DIFF
--- a/tests/test_zipstream.py
+++ b/tests/test_zipstream.py
@@ -517,6 +517,31 @@ def test_directly_adding_empty_dir(tmpdir):
     assert zinfos[0].compress_size == 0
 
 
+def test_add_path_dir_as_file(tmpdir):
+    t = tmpdir.mkdir("dir")
+    zs = ZipStream(sized=True)
+    zs.add_path(
+        t,
+        arcname="filename.txt",
+        recurse=False
+    )
+    assert zs.info_list()[0]["name"] == "filename.txt/"
+    assert len(zs) == len(bytes(zs))
+
+
+def test_add_path_file_as_dir(tmpdir):
+    t = tmpdir.join("file")
+    t.write(b"x")
+    zs = ZipStream(sized=True)
+    zs.add_path(
+        t,
+        arcname="dir/",
+        recurse=False
+    )
+    assert zs.info_list()[0]["name"] == "dir"
+    assert len(zs) == len(bytes(zs))
+
+
 def test_adding_local_dir(tmpdir):
     """Test adding files/folder from the local directory doesn't include the directory name of ."""
     t = tmpdir.mkdir("top")


### PR DESCRIPTION
Previously, it was possible to add a directory and give it an arcname that didn't end with a "/". Likewise, it was also possible to add a file with a arcname that ended with a "/". These cases would cause an incorrect stream size to be calculated, as well as create strange zip files.

This commit fixes this issue by modifying arcnames as paths are added to ensure that directories end with "/" and files do not.